### PR TITLE
Add targetSdkVersion Handling in Android Manifest Updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,111 @@
 # androidmanifest-changer
 
-Change Android AAB/APK attributes like the versionCode and versionName. This tool modified the binary AndroidManifest.xml within AAB (Bundles) and APK files.
+Change Android AAB/APK attributes like the versionCode and versionName. This tool modifies the binary AndroidManifest.xml within AAB (Bundles) and APK files.
+
 
 ## Supported attributes
 
-* minSdkVersion
-* versionCode
-* versionName
-* package
+- **minSdkVersion**
+	- The minSdkVersion set in your build.gradle file determines which APIs are available at build time (see compileSdkVersion to understand why this differs from Java builds), and determines the minimum version of the OS that your code will be compatible with.
+	- The minSdkVersion is used by the NDK to determine what features may be used when compiling your code.
+	- For example, this property determines which FORTIFY features are used in libc, and may also enable performance or size improvements (such as GNU hashes or RELR) for your binaries that are not compatible with older versions of Android.
+	- Even if you do not use any new APIs, this property still governs the minimum supported OS version of your code.
+	- Warning: Your app might work on older devices even if your native libraries are built with a newer minSdkVersion.
+	- Do not rely on this behavior. It is not guaranteed to work, and may not on other NDK versions, OS versions, or individual devices.
+	- For a new app, see the user distribution data in Android Studio's New Project Wizard or on apilevels.com.
+	- Choose your balance between potential market share and maintenance costs.
+	- The lower your minSdkVersion, the more time you'll spend working around old bugs and adding fallback behaviors for features that weren't implemented yet.
+	- For an existing app, raise your minSdkVersion whenever old API levels are no longer worth the maintenance costs, or lower it if your users demand it and it's worth the new maintenance costs.
+	- The Play console has metrics specific to your app's user distribution.
+	- Note: The NDK has its own minSdkVersion defined in <NDK>/meta/platforms.json. This is the lowest API level supported by the NDK. Do not set your app's minSdkVersion lower than this.
+	- Play may allow your app to be installed on older devices, but your NDK code may not work.
+	- The minSdkVersion of your application is made available to the preprocessor via the __ANDROID_MIN_SDK_VERSION__ macro (the legacy __ANDROID_API__ is identical, but prefer the former because its meaning is clearer).
+	- This macro is defined automatically by Clang, so no header needs to be included to use it. For NDK builds, this macro is always defined.
+
+- **versionCode**
+	- A positive integer used as an internal version number.
+	- This number helps determine whether one version is more recent than another, with higher numbers indicating more recent versions.
+	- This is not the version number shown to users; that number is set by the versionName setting.
+	- The Android system uses the versionCode value to protect against downgrades by preventing users from installing an APK with a lower versionCode than the version currently installed on their device.
+	- The value is a positive integer so that other apps can programmatically evaluate it—to check an upgrade or downgrade relationship, for instance.
+	- You can set the value to any positive integer. However, make sure that each successive release of your app uses a greater value.
+	- Note: The greatest value Google Play allows for versionCode is 2100000000.
+	- You can't upload an APK to the Play Store with a versionCode you have already used for a previous version.
+	- Note: In some situations, you might want to upload a version of your app with a lower versionCode than the most recent version.
+	- For example, if you are publishing multiple APKs, you might have pre-set versionCode ranges for specific APKs.
+	- For more about assigning versionCode values for multiple APKs, see Assigning version codes.
+	- Typically, you release the first version of your app with versionCode set to 1, then monotonically increase the value with each release, regardless of whether the release constitutes a major or minor release.
+	- This means that the versionCode value doesn't necessarily resemble the app release version that is visible to the user.
+	- Apps and publishing services shouldn't display this version value to users.
+
+- **versionName**
+	- A string used as the version number shown to users. This setting can be specified as a raw string or as a reference to a string resource.
+	- The value is a string so that you can describe the app version as a <major>.<minor>.<point> string or as any other type of absolute or relative version identifier.
+	- The versionName is the only value displayed to users.
+
+- **package**
+	- The value of the package attribute in the APK's manifest file represents your app's universally unique application ID.
+	- It is formatted as a full Java-language-style package name for the Android app.
+	- The name can contain uppercase or lowercase letters, numbers, and underscores ('_'). However, individual package name parts can only start with letters.
+	- Be careful not to change the package value, since that essentially creates a new app.
+	- Users of the previous version of your app don't receive an update and can't transfer their data between the old and new versions.
+	- In the Gradle-based build system, starting with AGP 7.3, don't set the package value in the source manifest file directly.
+	- For more information, see Set the application ID.
+
+
+## Coming soon
+
+- **targetSdkVersion**
+	- Similar to Java, the targetSdkVersion of your app can change the runtime behavior of native code. Behavior changes in the system are, when feasible, only applied to apps with a targetSdkVersion greater than or equal to the OS version that introduced the change.
+	- For a new app, choose the newest version available. For an existing app, update this to the latest version when convenient (after updating compileSdkVersion).
+	- While application developers generally know their app's targetSdkVersion, this API is useful for library developers that cannot know which targetSdkVersion their users will choose.
+	- At runtime, you can get the targetSdkVersion used by an application by calling android_get_application_target_sdk_version(). This API is available in API level 24 and later. This function has the following signature:
+```
+/**
+ * Returns the `targetSdkVersion` of the caller, or `__ANDROID_API_FUTURE__` if
+ * there is no known target SDK version (for code not running in the context of
+ * an app).
+ *
+ * The returned values correspond to the named constants in `<android/api-level.h>`,
+ * and is equivalent to the AndroidManifest.xml `targetSdkVersion`.
+ *
+ * See also android_get_device_api_level().
+ *
+ * Available since API level 24.
+ */
+int android_get_application_target_sdk_version() __INTRODUCED_IN(24);
+```
+`
+	- Other behavior changes might depend on the device API level. You can get the API level of the device your application is running on by calling android_get_device_api_level(). This function has the following signature:
+```
+/**
+ * Returns the API level of the device we're actually running on, or -1 on failure.
+ * The returned values correspond to the named constants in `<android/api-level.h>`,
+ * and is equivalent to the Java `Build.VERSION.SDK_INT` API.
+ *
+ * See also android_get_application_target_sdk_version().
+ */
+int android_get_device_api_level();
+```
+
+- **compileSdkVersion**
+	- This property has no effect on NDK builds. API availability for the NDK is instead governed by minSdkVersion.
+	- This is because C++ symbols are eagerly resolved at library load time rather than lazily resolved when first called (as they are in Java).
+	- Using any symbols that are not available in the minSdkVersion will cause the library to fail to load on OS versions that do not have the newer API, regardless of whether or not those APIs will be called.
+	- For a new app, choose the newest version available. For an existing app, update this to the latest version when convenient.
+
+- **compileSdkVersionCodename**
+
+
+- **platformBuildVersionCode**
+
+
+- **platformBuildVersionName**
+
 
 ## Usage
 
-```
+```bash
 # Change only versionCode
 androidmanifest-changer --versionCode 4 app.aab
 
@@ -25,6 +119,7 @@ androidmanifest-changer \
 ```
 
 This will rewrite the given aab/apk with the new values.
+
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,13 @@ Change Android AAB/APK attributes like the versionCode and versionName. This too
 ## Supported Attributes
 
 **minSdkVersion**
-   - The minSdkVersion set in your build.gradle file determines which APIs are available at build time (see compileSdkVersion to understand why this differs from Java builds), and determines the minimum version of the OS that your code will be compatible with.
-   - The minSdkVersion is used by the NDK to determine what features may be used when compiling your code.
-   - For example, this property determines which FORTIFY features are used in libc, and may also enable performance or size improvements (such as GNU hashes or RELR) for your binaries that are not compatible with older versions of Android.
-   - Even if you do not use any new APIs, this property still governs the minimum supported OS version of your code.
-   - Warning: Your app might work on older devices even if your native libraries are built with a newer minSdkVersion.
-   - Do not rely on this behavior. It is not guaranteed to work, and may not on other NDK versions, OS versions, or individual devices.
-   - For a new app, see the user distribution data in Android Studio's New Project Wizard or on apilevels.com.
-   - Choose your balance between potential market share and maintenance costs.
-   - The lower your minSdkVersion, the more time you'll spend working around old bugs and adding fallback behaviors for features that weren't implemented yet.
-   - For an existing app, raise your minSdkVersion whenever old API levels are no longer worth the maintenance costs, or lower it if your users demand it and it's worth the new maintenance costs.
-   - The Play console has metrics specific to your app's user distribution.
-   - Note: The NDK has its own minSdkVersion defined in <NDK>/meta/platforms.json. This is the lowest API level supported by the NDK. Do not set your app's minSdkVersion lower than this.
-   - Play may allow your app to be installed on older devices, but your NDK code may not work.
-   - The minSdkVersion of your application is made available to the preprocessor via the __ANDROID_MIN_SDK_VERSION__ macro (the legacy __ANDROID_API__ is identical, but prefer the former because its meaning is clearer).
-   - This macro is defined automatically by Clang, so no header needs to be included to use it. For NDK builds, this macro is always defined.
+   - An integer designating the minimum API level required for the application to run. 
+   - The Android system prevents the user from installing the application if the system's API level is lower than the value specified in this attribute. 
+   - Always declare this attribute.
+   - Caution: If you don't declare this attribute, the system assumes a default value of "1", which indicates that your application is compatible with all versions of Android. 
+   - If it isn't, and you didn't declare the proper minSdkVersion, then when installed on a system with an incompatible API level, the application crashes during runtime when attempting to access the unavailable APIs.
+   - For this reason, be certain to declare the appropriate API level in the minSdkVersion attribute.
+   - See https://developer.android.com/guide/topics/manifest/uses-sdk-element for more information.
 
 **versionCode**
    - A positive integer used as an internal version number.
@@ -37,11 +29,13 @@ Change Android AAB/APK attributes like the versionCode and versionName. This too
    - Typically, you release the first version of your app with versionCode set to 1, then monotonically increase the value with each release, regardless of whether the release constitutes a major or minor release.
    - This means that the versionCode value doesn't necessarily resemble the app release version that is visible to the user.
    - Apps and publishing services shouldn't display this version value to users.
+   - See https://developer.android.com/studio/publish/versioning for more information.
 
 **versionName**
    - A string used as the version number shown to users. This setting can be specified as a raw string or as a reference to a string resource.
    - The value is a string so that you can describe the app version as a <major>.<minor>.<point> string or as any other type of absolute or relative version identifier.
    - The versionName is the only value displayed to users.
+   - See https://developer.android.com/studio/publish/versioning for more information.
 
 **package**
    - The value of the package attribute in the APK's manifest file represents your app's universally unique application ID.
@@ -51,6 +45,7 @@ Change Android AAB/APK attributes like the versionCode and versionName. This too
    - Users of the previous version of your app don't receive an update and can't transfer their data between the old and new versions.
    - In the Gradle-based build system, starting with AGP 7.3, don't set the package value in the source manifest file directly.
    - For more information, see Set the application ID.
+   - See https://developer.android.com/guide/topics/manifest/manifest-element for more information.
 
 
 ## Coming soon
@@ -88,16 +83,19 @@ int android_get_application_target_sdk_version() __INTRODUCED_IN(24);
  */
 int android_get_device_api_level();
 ```
+   - See https://developer.android.com/ndk/guides/sdk-versions for more information.
 
 **compileSdkVersion**
    - This property has no effect on NDK builds. API availability for the NDK is instead governed by minSdkVersion.
    - This is because C++ symbols are eagerly resolved at library load time rather than lazily resolved when first called (as they are in Java).
    - Using any symbols that are not available in the minSdkVersion will cause the library to fail to load on OS versions that do not have the newer API, regardless of whether or not those APIs will be called.
    - For a new app, choose the newest version available. For an existing app, update this to the latest version when convenient.
+   - See https://developer.android.com/ndk/guides/sdk-versions for more information.
 
 **compileSdkVersionCodename**
    - The development codename (ex. "S", "REL") of the framework against which the application claims to have been compiled, or null if not specified.
    - This property is the compile-time equivalent of Build.VERSION.CODENAME.
+   - See https://developer.android.com/reference/android/content/pm/ApplicationInfo#compileSdkVersionCodename for more information.
 
 **platformBuildVersionCode**
 

--- a/README.md
+++ b/README.md
@@ -3,63 +3,65 @@
 Change Android AAB/APK attributes like the versionCode and versionName. This tool modifies the binary AndroidManifest.xml within AAB (Bundles) and APK files.
 
 
-## Supported attributes
+## Supported Attributes
 
-- **minSdkVersion**
-	- The minSdkVersion set in your build.gradle file determines which APIs are available at build time (see compileSdkVersion to understand why this differs from Java builds), and determines the minimum version of the OS that your code will be compatible with.
-	- The minSdkVersion is used by the NDK to determine what features may be used when compiling your code.
-	- For example, this property determines which FORTIFY features are used in libc, and may also enable performance or size improvements (such as GNU hashes or RELR) for your binaries that are not compatible with older versions of Android.
-	- Even if you do not use any new APIs, this property still governs the minimum supported OS version of your code.
-	- Warning: Your app might work on older devices even if your native libraries are built with a newer minSdkVersion.
-	- Do not rely on this behavior. It is not guaranteed to work, and may not on other NDK versions, OS versions, or individual devices.
-	- For a new app, see the user distribution data in Android Studio's New Project Wizard or on apilevels.com.
-	- Choose your balance between potential market share and maintenance costs.
-	- The lower your minSdkVersion, the more time you'll spend working around old bugs and adding fallback behaviors for features that weren't implemented yet.
-	- For an existing app, raise your minSdkVersion whenever old API levels are no longer worth the maintenance costs, or lower it if your users demand it and it's worth the new maintenance costs.
-	- The Play console has metrics specific to your app's user distribution.
-	- Note: The NDK has its own minSdkVersion defined in <NDK>/meta/platforms.json. This is the lowest API level supported by the NDK. Do not set your app's minSdkVersion lower than this.
-	- Play may allow your app to be installed on older devices, but your NDK code may not work.
-	- The minSdkVersion of your application is made available to the preprocessor via the __ANDROID_MIN_SDK_VERSION__ macro (the legacy __ANDROID_API__ is identical, but prefer the former because its meaning is clearer).
-	- This macro is defined automatically by Clang, so no header needs to be included to use it. For NDK builds, this macro is always defined.
+**minSdkVersion**
+   - The minSdkVersion set in your build.gradle file determines which APIs are available at build time (see compileSdkVersion to understand why this differs from Java builds), and determines the minimum version of the OS that your code will be compatible with.
+   - The minSdkVersion is used by the NDK to determine what features may be used when compiling your code.
+   - For example, this property determines which FORTIFY features are used in libc, and may also enable performance or size improvements (such as GNU hashes or RELR) for your binaries that are not compatible with older versions of Android.
+   - Even if you do not use any new APIs, this property still governs the minimum supported OS version of your code.
+   - Warning: Your app might work on older devices even if your native libraries are built with a newer minSdkVersion.
+   - Do not rely on this behavior. It is not guaranteed to work, and may not on other NDK versions, OS versions, or individual devices.
+   - For a new app, see the user distribution data in Android Studio's New Project Wizard or on apilevels.com.
+   - Choose your balance between potential market share and maintenance costs.
+   - The lower your minSdkVersion, the more time you'll spend working around old bugs and adding fallback behaviors for features that weren't implemented yet.
+   - For an existing app, raise your minSdkVersion whenever old API levels are no longer worth the maintenance costs, or lower it if your users demand it and it's worth the new maintenance costs.
+   - The Play console has metrics specific to your app's user distribution.
+   - Note: The NDK has its own minSdkVersion defined in <NDK>/meta/platforms.json. This is the lowest API level supported by the NDK. Do not set your app's minSdkVersion lower than this.
+   - Play may allow your app to be installed on older devices, but your NDK code may not work.
+   - The minSdkVersion of your application is made available to the preprocessor via the __ANDROID_MIN_SDK_VERSION__ macro (the legacy __ANDROID_API__ is identical, but prefer the former because its meaning is clearer).
+   - This macro is defined automatically by Clang, so no header needs to be included to use it. For NDK builds, this macro is always defined.
 
-- **versionCode**
-	- A positive integer used as an internal version number.
-	- This number helps determine whether one version is more recent than another, with higher numbers indicating more recent versions.
-	- This is not the version number shown to users; that number is set by the versionName setting.
-	- The Android system uses the versionCode value to protect against downgrades by preventing users from installing an APK with a lower versionCode than the version currently installed on their device.
-	- The value is a positive integer so that other apps can programmatically evaluate it—to check an upgrade or downgrade relationship, for instance.
-	- You can set the value to any positive integer. However, make sure that each successive release of your app uses a greater value.
-	- Note: The greatest value Google Play allows for versionCode is 2100000000.
-	- You can't upload an APK to the Play Store with a versionCode you have already used for a previous version.
-	- Note: In some situations, you might want to upload a version of your app with a lower versionCode than the most recent version.
-	- For example, if you are publishing multiple APKs, you might have pre-set versionCode ranges for specific APKs.
-	- For more about assigning versionCode values for multiple APKs, see Assigning version codes.
-	- Typically, you release the first version of your app with versionCode set to 1, then monotonically increase the value with each release, regardless of whether the release constitutes a major or minor release.
-	- This means that the versionCode value doesn't necessarily resemble the app release version that is visible to the user.
-	- Apps and publishing services shouldn't display this version value to users.
+**versionCode**
+   - A positive integer used as an internal version number.
+   - This number helps determine whether one version is more recent than another, with higher numbers indicating more recent versions.
+   - This is not the version number shown to users; that number is set by the versionName setting.
+   - The Android system uses the versionCode value to protect against downgrades by preventing users from installing an APK with a lower versionCode than the version currently installed on their device.
+   - The value is a positive integer so that other apps can programmatically evaluate it—to check an upgrade or downgrade relationship, for instance.
+   - You can set the value to any positive integer. However, make sure that each successive release of your app uses a greater value.
+   - Note: The greatest value Google Play allows for versionCode is 2100000000.
+   - You can't upload an APK to the Play Store with a versionCode you have already used for a previous version.
+   - Note: In some situations, you might want to upload a version of your app with a lower versionCode than the most recent version.
+   - For example, if you are publishing multiple APKs, you might have pre-set versionCode ranges for specific APKs.
+   - For more about assigning versionCode values for multiple APKs, see Assigning version codes.
+   - Typically, you release the first version of your app with versionCode set to 1, then monotonically increase the value with each release, regardless of whether the release constitutes a major or minor release.
+   - This means that the versionCode value doesn't necessarily resemble the app release version that is visible to the user.
+   - Apps and publishing services shouldn't display this version value to users.
 
-- **versionName**
-	- A string used as the version number shown to users. This setting can be specified as a raw string or as a reference to a string resource.
-	- The value is a string so that you can describe the app version as a <major>.<minor>.<point> string or as any other type of absolute or relative version identifier.
-	- The versionName is the only value displayed to users.
+**versionName**
+   - A string used as the version number shown to users. This setting can be specified as a raw string or as a reference to a string resource.
+   - The value is a string so that you can describe the app version as a <major>.<minor>.<point> string or as any other type of absolute or relative version identifier.
+   - The versionName is the only value displayed to users.
 
-- **package**
-	- The value of the package attribute in the APK's manifest file represents your app's universally unique application ID.
-	- It is formatted as a full Java-language-style package name for the Android app.
-	- The name can contain uppercase or lowercase letters, numbers, and underscores ('_'). However, individual package name parts can only start with letters.
-	- Be careful not to change the package value, since that essentially creates a new app.
-	- Users of the previous version of your app don't receive an update and can't transfer their data between the old and new versions.
-	- In the Gradle-based build system, starting with AGP 7.3, don't set the package value in the source manifest file directly.
-	- For more information, see Set the application ID.
+**package**
+   - The value of the package attribute in the APK's manifest file represents your app's universally unique application ID.
+   - It is formatted as a full Java-language-style package name for the Android app.
+   - The name can contain uppercase or lowercase letters, numbers, and underscores ('_'). However, individual package name parts can only start with letters.
+   - Be careful not to change the package value, since that essentially creates a new app.
+   - Users of the previous version of your app don't receive an update and can't transfer their data between the old and new versions.
+   - In the Gradle-based build system, starting with AGP 7.3, don't set the package value in the source manifest file directly.
+   - For more information, see Set the application ID.
 
 
 ## Coming soon
 
-- **targetSdkVersion**
-	- Similar to Java, the targetSdkVersion of your app can change the runtime behavior of native code. Behavior changes in the system are, when feasible, only applied to apps with a targetSdkVersion greater than or equal to the OS version that introduced the change.
-	- For a new app, choose the newest version available. For an existing app, update this to the latest version when convenient (after updating compileSdkVersion).
-	- While application developers generally know their app's targetSdkVersion, this API is useful for library developers that cannot know which targetSdkVersion their users will choose.
-	- At runtime, you can get the targetSdkVersion used by an application by calling android_get_application_target_sdk_version(). This API is available in API level 24 and later. This function has the following signature:
+**targetSdkVersion**
+   - Similar to Java, the targetSdkVersion of your app can change the runtime behavior of native code.
+   - Behavior changes in the system are, when feasible, only applied to apps with a targetSdkVersion greater than or equal to the OS version that introduced the change.
+   - For a new app, choose the newest version available. For an existing app, update this to the latest version when convenient (after updating compileSdkVersion).
+   - While application developers generally know their app's targetSdkVersion, this API is useful for library developers that cannot know which targetSdkVersion their users will choose.
+   - At runtime, you can get the targetSdkVersion used by an application by calling android_get_application_target_sdk_version().
+   - This API is available in API level 24 and later. This function has the following signature:
 ```
 /**
  * Returns the `targetSdkVersion` of the caller, or `__ANDROID_API_FUTURE__` if
@@ -75,8 +77,7 @@ Change Android AAB/APK attributes like the versionCode and versionName. This too
  */
 int android_get_application_target_sdk_version() __INTRODUCED_IN(24);
 ```
-`
-	- Other behavior changes might depend on the device API level. You can get the API level of the device your application is running on by calling android_get_device_api_level(). This function has the following signature:
+   - Other behavior changes might depend on the device API level. You can get the API level of the device your application is running on by calling android_get_device_api_level(). This function has the following signature:
 ```
 /**
  * Returns the API level of the device we're actually running on, or -1 on failure.
@@ -88,19 +89,20 @@ int android_get_application_target_sdk_version() __INTRODUCED_IN(24);
 int android_get_device_api_level();
 ```
 
-- **compileSdkVersion**
-	- This property has no effect on NDK builds. API availability for the NDK is instead governed by minSdkVersion.
-	- This is because C++ symbols are eagerly resolved at library load time rather than lazily resolved when first called (as they are in Java).
-	- Using any symbols that are not available in the minSdkVersion will cause the library to fail to load on OS versions that do not have the newer API, regardless of whether or not those APIs will be called.
-	- For a new app, choose the newest version available. For an existing app, update this to the latest version when convenient.
+**compileSdkVersion**
+   - This property has no effect on NDK builds. API availability for the NDK is instead governed by minSdkVersion.
+   - This is because C++ symbols are eagerly resolved at library load time rather than lazily resolved when first called (as they are in Java).
+   - Using any symbols that are not available in the minSdkVersion will cause the library to fail to load on OS versions that do not have the newer API, regardless of whether or not those APIs will be called.
+   - For a new app, choose the newest version available. For an existing app, update this to the latest version when convenient.
 
-- **compileSdkVersionCodename**
+**compileSdkVersionCodename**
+   - The development codename (ex. "S", "REL") of the framework against which the application claims to have been compiled, or null if not specified.
+   - This property is the compile-time equivalent of Build.VERSION.CODENAME.
+
+**platformBuildVersionCode**
 
 
-- **platformBuildVersionCode**
-
-
-- **platformBuildVersionName**
+**platformBuildVersionName**
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,101 +6,69 @@ Change Android AAB/APK attributes like the versionCode and versionName. This too
 ## Supported Attributes
 
 **minSdkVersion**
-   - An integer designating the minimum API level required for the application to run. 
-   - The Android system prevents the user from installing the application if the system's API level is lower than the value specified in this attribute. 
-   - Always declare this attribute.
-   - Caution: If you don't declare this attribute, the system assumes a default value of "1", which indicates that your application is compatible with all versions of Android. 
-   - If it isn't, and you didn't declare the proper minSdkVersion, then when installed on a system with an incompatible API level, the application crashes during runtime when attempting to access the unavailable APIs.
-   - For this reason, be certain to declare the appropriate API level in the minSdkVersion attribute.
+   - Integer specifying the minimum Android API level required for the app to run.
+   - Android system blocks installation on devices with API levels lower than this value.
+   - Default assumed value is "1" if not specified, implying compatibility with all Android versions.
+   - Not declaring this attribute can lead to app crashes on incompatible systems due to unavailable APIs.
+   - Critical to specify the correct minSdkVersion for app stability.
    - See https://developer.android.com/guide/topics/manifest/uses-sdk-element for more information.
 
+
 **versionCode**
-   - A positive integer used as an internal version number.
-   - This number helps determine whether one version is more recent than another, with higher numbers indicating more recent versions.
-   - This is not the version number shown to users; that number is set by the versionName setting.
-   - The Android system uses the versionCode value to protect against downgrades by preventing users from installing an APK with a lower versionCode than the version currently installed on their device.
-   - The value is a positive integer so that other apps can programmatically evaluate it—to check an upgrade or downgrade relationship, for instance.
-   - You can set the value to any positive integer. However, make sure that each successive release of your app uses a greater value.
-   - Note: The greatest value Google Play allows for versionCode is 2100000000.
-   - You can't upload an APK to the Play Store with a versionCode you have already used for a previous version.
-   - Note: In some situations, you might want to upload a version of your app with a lower versionCode than the most recent version.
-   - For example, if you are publishing multiple APKs, you might have pre-set versionCode ranges for specific APKs.
-   - For more about assigning versionCode values for multiple APKs, see Assigning version codes.
-   - Typically, you release the first version of your app with versionCode set to 1, then monotonically increase the value with each release, regardless of whether the release constitutes a major or minor release.
-   - This means that the versionCode value doesn't necessarily resemble the app release version that is visible to the user.
-   - Apps and publishing services shouldn't display this version value to users.
+   - A positive integer that serves as the internal version number of the app.
+   - Used to differentiate between newer and older versions, with higher numbers indicating more recent versions.
+   - Not visible to users, as the versionName attribute is used for display.
+   - Prevents downgrading by blocking the installation of APKs with lower versionCodes than the one installed.
+   - Important to increment for each app update.
+   - Maximum allowable value on Google Play: 2100000000.
+   - Reuse of versionCode for Play Store uploads is not permitted.
    - See https://developer.android.com/studio/publish/versioning for more information.
+
 
 **versionName**
-   - A string used as the version number shown to users. This setting can be specified as a raw string or as a reference to a string resource.
-   - The value is a string so that you can describe the app version as a <major>.<minor>.<point> string or as any other type of absolute or relative version identifier.
-   - The versionName is the only value displayed to users.
+   - The version number shown to users, specified as a string.
+   - Flexible format, commonly used as <major>.<minor>.<point> or other version identifiers.
+   - The primary version identifier for end users.
    - See https://developer.android.com/studio/publish/versioning for more information.
 
+
 **package**
-   - The value of the package attribute in the APK's manifest file represents your app's universally unique application ID.
-   - It is formatted as a full Java-language-style package name for the Android app.
-   - The name can contain uppercase or lowercase letters, numbers, and underscores ('_'). However, individual package name parts can only start with letters.
-   - Be careful not to change the package value, since that essentially creates a new app.
-   - Users of the previous version of your app don't receive an update and can't transfer their data between the old and new versions.
-   - In the Gradle-based build system, starting with AGP 7.3, don't set the package value in the source manifest file directly.
-   - For more information, see Set the application ID.
+   - Represents the app's unique application ID, formatted as a Java package name.
+   - Can include uppercase and lowercase letters, numbers, and underscores, but must start with a letter.
+   - Modifying this value essentially creates a new application, impacting updates and data transfer.
+   - In AGP 7.3+, avoid setting this directly in the source manifest.
    - See https://developer.android.com/guide/topics/manifest/manifest-element for more information.
 
 
 ## Coming soon
 
 **targetSdkVersion**
-   - Similar to Java, the targetSdkVersion of your app can change the runtime behavior of native code.
-   - Behavior changes in the system are, when feasible, only applied to apps with a targetSdkVersion greater than or equal to the OS version that introduced the change.
-   - For a new app, choose the newest version available. For an existing app, update this to the latest version when convenient (after updating compileSdkVersion).
-   - While application developers generally know their app's targetSdkVersion, this API is useful for library developers that cannot know which targetSdkVersion their users will choose.
-   - At runtime, you can get the targetSdkVersion used by an application by calling android_get_application_target_sdk_version().
-   - This API is available in API level 24 and later. This function has the following signature:
-```
-/**
- * Returns the `targetSdkVersion` of the caller, or `__ANDROID_API_FUTURE__` if
- * there is no known target SDK version (for code not running in the context of
- * an app).
- *
- * The returned values correspond to the named constants in `<android/api-level.h>`,
- * and is equivalent to the AndroidManifest.xml `targetSdkVersion`.
- *
- * See also android_get_device_api_level().
- *
- * Available since API level 24.
- */
-int android_get_application_target_sdk_version() __INTRODUCED_IN(24);
-```
-   - Other behavior changes might depend on the device API level. You can get the API level of the device your application is running on by calling android_get_device_api_level(). This function has the following signature:
-```
-/**
- * Returns the API level of the device we're actually running on, or -1 on failure.
- * The returned values correspond to the named constants in `<android/api-level.h>`,
- * and is equivalent to the Java `Build.VERSION.SDK_INT` API.
- *
- * See also android_get_application_target_sdk_version().
- */
-int android_get_device_api_level();
-```
+   - Influences the runtime behavior of the app's native code.
+   - System applies behavior changes to apps with targetSdkVersion at or above the OS version introducing these changes.
+   - New apps should target the latest version; existing apps should update when feasible.
+   - Retrieve the targetSdkVersion at runtime with android_get_application_target_sdk_version() in API level 24 and later.
    - See https://developer.android.com/ndk/guides/sdk-versions for more information.
+
 
 **compileSdkVersion**
-   - This property has no effect on NDK builds. API availability for the NDK is instead governed by minSdkVersion.
-   - This is because C++ symbols are eagerly resolved at library load time rather than lazily resolved when first called (as they are in Java).
-   - Using any symbols that are not available in the minSdkVersion will cause the library to fail to load on OS versions that do not have the newer API, regardless of whether or not those APIs will be called.
-   - For a new app, choose the newest version available. For an existing app, update this to the latest version when convenient.
+   - Determines the API availability for NDK builds, independent of the compileSdkVersion property.
+   - Governed by minSdkVersion, as C++ symbols are resolved at library load time.
+   - Recommended to use the newest version for new apps and update existing apps as needed.
    - See https://developer.android.com/ndk/guides/sdk-versions for more information.
 
+
 **compileSdkVersionCodename**
-   - The development codename (ex. "S", "REL") of the framework against which the application claims to have been compiled, or null if not specified.
-   - This property is the compile-time equivalent of Build.VERSION.CODENAME.
+   - Reflects the development codename of the Android framework used for compiling the app.
+   - Compile-time equivalent of Build.VERSION.CODENAME.
    - See https://developer.android.com/reference/android/content/pm/ApplicationInfo#compileSdkVersionCodename for more information.
 
+
 **platformBuildVersionCode**
+   - Description unavailable.
 
 
 **platformBuildVersionName**
+   - Description unavailable.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Change Android AAB/APK attributes like the versionCode and versionName. This too
    - See https://developer.android.com/guide/topics/manifest/uses-sdk-element for more information.
 
 
+**targetSdkVersion**
+   - Influences the runtime behavior of the app's native code.
+   - System applies behavior changes to apps with targetSdkVersion at or above the OS version introducing these changes.
+   - New apps should target the latest version; existing apps should update when feasible.
+   - Retrieve the targetSdkVersion at runtime with android_get_application_target_sdk_version() in API level 24 and later.
+   - See https://developer.android.com/ndk/guides/sdk-versions for more information.
+
+
 **versionCode**
    - A positive integer that serves as the internal version number of the app.
    - Used to differentiate between newer and older versions, with higher numbers indicating more recent versions.
@@ -41,14 +49,6 @@ Change Android AAB/APK attributes like the versionCode and versionName. This too
 
 
 ## Coming soon
-
-**targetSdkVersion**
-   - Influences the runtime behavior of the app's native code.
-   - System applies behavior changes to apps with targetSdkVersion at or above the OS version introducing these changes.
-   - New apps should target the latest version; existing apps should update when feasible.
-   - Retrieve the targetSdkVersion at runtime with android_get_application_target_sdk_version() in API level 24 and later.
-   - See https://developer.android.com/ndk/guides/sdk-versions for more information.
-
 
 **compileSdkVersion**
    - This property doesn't impact NDK builds as API availability for NDK is determined by minSdkVersion.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ Change Android AAB/APK attributes like the versionCode and versionName. This too
 
 
 **compileSdkVersion**
-   - Determines the API availability for NDK builds, independent of the compileSdkVersion property.
-   - Governed by minSdkVersion, as C++ symbols are resolved at library load time.
-   - Recommended to use the newest version for new apps and update existing apps as needed.
+   - This property doesn't impact NDK builds as API availability for NDK is determined by minSdkVersion.
+   - In NDK, C++ symbols are resolved at library load time, unlike the lazy resolution in Java.
+   - Utilizing symbols not present in the minSdkVersion can lead to library loading failures on OS versions lacking the newer API.
+   - Recommended approach for new apps is to use the latest available version. For existing apps, update to the latest version as per development needs.
    - See https://developer.android.com/ndk/guides/sdk-versions for more information.
 
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type Config struct {
 	versionName string
 	packageName string
 	minSdkVersion int
+	targetSdkVersion int
 }
 
 func main() {
@@ -37,6 +38,7 @@ func main() {
 	versionName := flag.String("versionName", "", "The versionName to set")
 	packageName := flag.String("package", "", "The package to set")
 	minSdkVersion := flag.Int("minSdkVersion", 0, "The minSdkVersion to set")
+	targetSdkVersion := flag.Int("targetSdkVersion", 0, "The targetSdkVersion to set")
 	flag.Parse()
 	if len(flag.Args()) != 1 {
 		fmt.Fprintln(flag.CommandLine.Output(), "Error: File path is required.")
@@ -48,6 +50,7 @@ func main() {
 		versionName: *versionName,
 		packageName: *packageName,
 		minSdkVersion: *minSdkVersion,
+		targetSdkVersion: *targetSdkVersion,
 	}
 
 	path := flag.Arg(0)
@@ -180,6 +183,11 @@ func updateManifest(path string, config *Config) {
 							if config.minSdkVersion > 0 {
 								fmt.Println("Changing minSdkVersion from", attr.Value, "to", config.minSdkVersion)
 								attr.Value = strconv.Itoa(config.minSdkVersion)
+							}
+						case "targetSdkVersion":
+							if config.targetSdkVersion > 0 {
+								fmt.Println("Changing targetSdkVersion from", attr.Value, "to", config.targetSdkVersion)
+								attr.Value = strconv.Itoa(config.targetSdkVersion)
 							}
 						}
 					}


### PR DESCRIPTION
This commit introduces the functionality to modify the targetSdkVersion in Android APK and AAB manifests. The changes enhance the existing command-line utility, allowing users to specify a targetSdkVersion alongside other configurable manifest attributes like minSdkVersion, versionCode, and versionName.

Key Changes:
- Updated the Config struct to include a targetSdkVersion field.
- Added a new command-line flag, 'targetSdkVersion', to accept user input for the target SDK version.
- Modified the updateManifest function to handle the new targetSdkVersion. The function now checks for the 'uses-sdk' element in the XML and updates the targetSdkVersion attribute if a new value is provided.
- Ensured that the switch statement in the updateManifest function is properly structured to handle both minSdkVersion and targetSdkVersion updates.

These changes allow for more comprehensive and flexible manipulation of Android manifest files, facilitating easier version management and updates for APK and AAB files.

Testing:
- Conducted tests with sample APK and AAB files to ensure that the targetSdkVersion is correctly updated without impacting the integrity of the manifest file.
- Verified that the program's existing functionality for other manifest attributes remains unaffected.